### PR TITLE
Validates the destination address for SES

### DIFF
--- a/terraform/common/ses.tf
+++ b/terraform/common/ses.tf
@@ -1,3 +1,7 @@
+resource "aws_ses_email_identity" "notify_email" {
+  email = "trade-tariff-support@enginegroup.com"
+}
+
 resource "aws_ses_domain_identity" "tariff_domain" {
   domain = "trade-tariff.service.gov.uk"
 }


### PR DESCRIPTION
What:

Creates a SES identity validation for the destination email

Why:

So that we can receive emails from SES on trade-tariff-support@enginegroup.com