### PR TITLE
Hott-203 Adds a CDN to the API service

### DIFF
--- a/terraform/api-docs/acm.tf
+++ b/terraform/api-docs/acm.tf
@@ -1,0 +1,33 @@
+resource "aws_acm_certificate" "cdn_certificate" {
+  provider                  = aws.global
+  domain_name               = var.fqdn
+  subject_alternative_names = var.aliases
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "validation_records" {
+  for_each = {
+    for dvo in aws_acm_certificate.cdn_certificate.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  zone_id         = data.aws_route53_zone.selected.zone_id
+  name            = each.value.name
+  records         = [each.value.record]
+  type            = each.value.type
+  ttl             = 60
+}
+
+resource "aws_acm_certificate_validation" "validation" {
+  provider = aws.global
+  certificate_arn         = aws_acm_certificate.cdn_certificate.arn
+  validation_record_fqdns = [for record in aws_route53_record.validation_records : record.fqdn]
+}

--- a/terraform/api-docs/backends/development.backend
+++ b/terraform/api-docs/backends/development.backend
@@ -1,0 +1,3 @@
+bucket = "trade-tariff-terraform-state"
+key    = "api-docs-development"
+region = "eu-west-2"

--- a/terraform/api-docs/backends/production.backend
+++ b/terraform/api-docs/backends/production.backend
@@ -1,0 +1,3 @@
+bucket = "trade-tariff-terraform-state"
+key    = "api-docs-production"
+region = "eu-west-2"

--- a/terraform/api-docs/cloudfront.tf
+++ b/terraform/api-docs/cloudfront.tf
@@ -60,6 +60,7 @@ data "aws_route53_zone" "selected" {
 resource "aws_route53_record" "cdn-record" {
   name = "api-dev.trade-tariff.service.gov.uk"
   type = "CNAME"
+  ttl = 60
   records = [aws_cloudfront_distribution.distribution.domain_name]
   zone_id = data.aws_route53_zone.selected.id
 }

--- a/terraform/api-docs/cloudfront.tf
+++ b/terraform/api-docs/cloudfront.tf
@@ -1,0 +1,65 @@
+resource "aws_cloudfront_distribution" "distribution" {
+  origin {
+    domain_name = "tariff-api-dev.london.cloudapps.digital"
+    origin_id   = "origin-tariff-api-dev.london.cloudapps.digital"
+
+    custom_origin_config {
+      http_port = 80
+      https_port = 443
+      origin_keepalive_timeout = 5
+      origin_protocol_policy = "match-viewer"
+      origin_read_timeout = 30
+      origin_ssl_protocols = ["TLSv1.1","TLSv1.2"]
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  price_class = "PriceClass_100"
+
+  aliases = [ "api-dev.trade-tariff.service.gov.uk"]
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "origin-tariff-api-dev.london.cloudapps.digital"
+
+    forwarded_values {
+      query_string = true
+      cookies {
+        forward = "all"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 0
+    max_ttl                = 0
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = false
+    acm_certificate_arn = "arn:aws:acm:us-east-1:777015734912:certificate/59c22c7f-fbb5-4fc7-955f-00595c565a3b"
+    minimum_protocol_version = "TLSv1.1_2016"
+    ssl_support_method = "sni-only"
+  }
+}
+
+
+data "aws_route53_zone" "selected" {
+  name         = "trade-tariff.service.gov.uk."
+  private_zone = false
+}
+
+resource "aws_route53_record" "cdn-record" {
+  name = "api-dev.trade-tariff.service.gov.uk"
+  type = "CNAME"
+  records = [aws_cloudfront_distribution.distribution.domain_name]
+  zone_id = data.aws_route53_zone.selected.id
+}

--- a/terraform/api-docs/cloudfront.tf
+++ b/terraform/api-docs/cloudfront.tf
@@ -18,7 +18,7 @@ resource "aws_cloudfront_distribution" "distribution" {
   is_ipv6_enabled = true
   price_class     = "PriceClass_100"
 
-  aliases = var.aliases
+  aliases = concat([var.fqdn],var.aliases,)
 
   default_cache_behavior {
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]

--- a/terraform/api-docs/cloudfront.tf
+++ b/terraform/api-docs/cloudfront.tf
@@ -1,28 +1,29 @@
 resource "aws_cloudfront_distribution" "distribution" {
+  provider = aws.global
   origin {
-    domain_name = "tariff-api-dev.london.cloudapps.digital"
-    origin_id   = "origin-tariff-api-dev.london.cloudapps.digital"
+    domain_name = var.origin_endpoint
+    origin_id   = "origin-${var.origin_endpoint}"
 
     custom_origin_config {
-      http_port = 80
-      https_port = 443
+      http_port                = 80
+      https_port               = 443
       origin_keepalive_timeout = 5
-      origin_protocol_policy = "match-viewer"
-      origin_read_timeout = 30
-      origin_ssl_protocols = ["TLSv1.1","TLSv1.2"]
+      origin_protocol_policy   = "match-viewer"
+      origin_read_timeout      = 30
+      origin_ssl_protocols     = ["TLSv1.1", "TLSv1.2"]
     }
   }
 
-  enabled             = true
-  is_ipv6_enabled     = true
-  price_class = "PriceClass_100"
+  enabled         = true
+  is_ipv6_enabled = true
+  price_class     = "PriceClass_100"
 
-  aliases = [ "api-dev.trade-tariff.service.gov.uk"]
+  aliases = var.aliases
 
   default_cache_behavior {
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD"]
-    target_origin_id = "origin-tariff-api-dev.london.cloudapps.digital"
+    target_origin_id = "origin-${var.origin_endpoint}"
 
     forwarded_values {
       query_string = true
@@ -45,22 +46,21 @@ resource "aws_cloudfront_distribution" "distribution" {
 
   viewer_certificate {
     cloudfront_default_certificate = false
-    acm_certificate_arn = "arn:aws:acm:us-east-1:777015734912:certificate/59c22c7f-fbb5-4fc7-955f-00595c565a3b"
-    minimum_protocol_version = "TLSv1.1_2016"
-    ssl_support_method = "sni-only"
+    acm_certificate_arn            = aws_acm_certificate.cdn_certificate.arn
+    minimum_protocol_version       = "TLSv1.1_2016"
+    ssl_support_method             = "sni-only"
   }
-}
 
-
-data "aws_route53_zone" "selected" {
-  name         = "trade-tariff.service.gov.uk."
-  private_zone = false
+  depends_on = [
+    aws_acm_certificate.cdn_certificate,
+    aws_acm_certificate_validation.validation
+  ]
 }
 
 resource "aws_route53_record" "cdn-record" {
-  name = "api-dev.trade-tariff.service.gov.uk"
-  type = "CNAME"
-  ttl = 60
+  name    = var.fqdn
+  type    = "CNAME"
+  ttl     = 60
   records = [aws_cloudfront_distribution.distribution.domain_name]
   zone_id = data.aws_route53_zone.selected.id
 }

--- a/terraform/api-docs/main.tf
+++ b/terraform/api-docs/main.tf
@@ -5,3 +5,18 @@ terraform {
     region = "eu-west-2"
   }
 }
+
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "global"
+  region = "us-east-1"
+}
+
+data "aws_route53_zone" "selected" {
+  name         = "trade-tariff.service.gov.uk."
+  private_zone = false
+}

--- a/terraform/api-docs/main.tf
+++ b/terraform/api-docs/main.tf
@@ -1,8 +1,5 @@
 terraform {
   backend "s3" {
-    bucket = "trade-tariff-terraform-state"
-    key    = "api-docs"
-    region = "eu-west-2"
   }
 }
 

--- a/terraform/api-docs/main.tf
+++ b/terraform/api-docs/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "trade-tariff-terraform-state"
+    key    = "api-docs"
+    region = "eu-west-2"
+  }
+}

--- a/terraform/api-docs/variables.tf
+++ b/terraform/api-docs/variables.tf
@@ -1,0 +1,15 @@
+variable "environment_name" {
+}
+
+variable "environment_key" {
+}
+
+variable "origin_endpoint" {
+}
+
+variable "fqdn" {
+}
+
+variable "aliases" {
+  type = list(string)
+}

--- a/terraform/api-docs/vars/development.tf
+++ b/terraform/api-docs/vars/development.tf
@@ -1,0 +1,5 @@
+environment_name="development"
+environment_key="dev"
+fqdn="api-dev.trade-tariff.service.gov.uk"
+aliases = [ "api-dev.trade-tariff.service.gov.uk"]
+origin_endpoint="tariff-api-dev.london.cloudapps.digital"

--- a/terraform/api-docs/vars/development.tf
+++ b/terraform/api-docs/vars/development.tf
@@ -1,5 +1,5 @@
 environment_name="development"
 environment_key="dev"
 fqdn="api-dev.trade-tariff.service.gov.uk"
-aliases = [ "api-dev.trade-tariff.service.gov.uk"]
+aliases = [ ]
 origin_endpoint="tariff-api-dev.london.cloudapps.digital"

--- a/terraform/api-docs/vars/production.tf
+++ b/terraform/api-docs/vars/production.tf
@@ -1,5 +1,5 @@
 environment_name="production"
 environment_key="production"
 fqdn="api.trade-tariff.service.gov.uk"
-aliases = [ "api.trade-tariff.service.gov.uk"]
+aliases = [ ]
 origin_endpoint="tariff-api-production.london.cloudapps.digital"

--- a/terraform/api-docs/vars/production.tf
+++ b/terraform/api-docs/vars/production.tf
@@ -1,0 +1,5 @@
+environment_name="production"
+environment_key="production"
+fqdn="api.trade-tariff.service.gov.uk"
+aliases = [ "api.trade-tariff.service.gov.uk"]
+origin_endpoint="tariff-api-production.london.cloudapps.digital"


### PR DESCRIPTION
What:
Creates a CDN for the API service, with configuration per environment
Creates and validates the respective ACM certificate.

Why:
We need to take over this CDN into our account.
We want this to be persisted in code