### PR TITLE
HOTT-363 custom policies production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ crash.log
 # control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 #
-*.tfvars
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in

--- a/terraform/cdn/vars/production.tfvars
+++ b/terraform/cdn/vars/production.tfvars
@@ -1,0 +1,4 @@
+environment_name="production"
+environment_key="production"
+cdn_aliases = ["www.trade-tariff.service.gov.uk","assets.trade-tariff.service.gov.uk" ]
+origin_endpoint="tariff-frontend-production.london.cloudapps.digital"


### PR DESCRIPTION
What: 

* Add the configuration for the production CDN to version control
* Fix .gitignore to allow pushing .tfvars

Why:
This was the final step to bring the CDN configuration under Terraform control